### PR TITLE
Fix auto scrolling not working correctly at 125% screen scaling

### DIFF
--- a/assets/console.js
+++ b/assets/console.js
@@ -117,7 +117,7 @@ window.addEventListener('load', () => {
 
   const consoleWindow = document.getElementById('console-output-wrapper');
   consoleWindow.addEventListener('scroll', (evt) => {
-    autoScrollPaused = (consoleWindow.scrollTop + consoleWindow.offsetHeight) < consoleWindow.scrollHeight;
+    autoScrollPaused = Math.ceil(consoleWindow.scrollTop + consoleWindow.offsetHeight) < consoleWindow.scrollHeight;
   });
 });
 


### PR DESCRIPTION
Fix auto scrolling not working correctly at 125% screen scaling in Windows